### PR TITLE
refactor: make DummyDA publicly available

### DIFF
--- a/da.go
+++ b/da.go
@@ -2,7 +2,7 @@ package da
 
 // DA defines very generic interface for interaction with Data Availability layers.
 type DA interface {
-	// Get returns Blob for given ID, or an error.
+	// Get returns Blob for each given ID, or an error.
 	//
 	// Error should be returned if ID is not formatted properly, there is no Blob for given ID or any other client-level
 	// error occurred (dropped connection, timeout, etc).
@@ -11,16 +11,16 @@ type DA interface {
 	// GetIDs returns IDs of all Blobs located in DA at given height.
 	GetIDs(height uint64) ([]ID, error)
 
-	// Commit creates a Commitment for the given Blob.
+	// Commit creates a Commitment for each given Blob.
 	Commit(blobs []Blob) ([]Commitment, error)
 
-	// Submit submits a Blob to Data Availability layer.
+	// Submit submits a Blobs to Data Availability layer.
 	//
 	// This method is synchronous. Upon successful submission to Data Availability layer, it returns ID identifying blob
 	// in DA and Proof of inclusion.
 	Submit(blobs []Blob) ([]ID, []Proof, error)
 
-	// Validate validates Commitment against Proof. This should be possible without retrieving Blob.
+	// Validate validates Commitments against corresponding Proofs. This should be possible without retrieving Blob.
 	Validate(ids []ID, proofs []Proof) ([]bool, error)
 }
 

--- a/da.go
+++ b/da.go
@@ -14,13 +14,13 @@ type DA interface {
 	// Commit creates a Commitment for each given Blob.
 	Commit(blobs []Blob) ([]Commitment, error)
 
-	// Submit submits a Blobs to Data Availability layer.
+	// Submit submits the Blobs to Data Availability layer.
 	//
 	// This method is synchronous. Upon successful submission to Data Availability layer, it returns ID identifying blob
 	// in DA and Proof of inclusion.
 	Submit(blobs []Blob) ([]ID, []Proof, error)
 
-	// Validate validates Commitments against corresponding Proofs. This should be possible without retrieving Blob.
+	// Validate validates Commitments against the corresponding Proofs. This should be possible without retrieving the Blobs.
 	Validate(ids []ID, proofs []Proof) ([]bool, error)
 }
 

--- a/da_test.go
+++ b/da_test.go
@@ -2,9 +2,10 @@ package da_test
 
 import (
 	"bytes"
-	"github.com/rollkit/go-da/test"
 	"testing"
 	"time"
+
+	"github.com/rollkit/go-da/test"
 
 	"github.com/stretchr/testify/assert"
 

--- a/da_test.go
+++ b/da_test.go
@@ -2,6 +2,7 @@ package da_test
 
 import (
 	"bytes"
+	"github.com/rollkit/go-da/test"
 	"testing"
 	"time"
 
@@ -11,7 +12,11 @@ import (
 )
 
 func TestDummyDA(t *testing.T) {
-	dummy := NewDummyDA()
+	dummy := test.NewDummyDA()
+	RunDATestSuite(t, dummy)
+}
+
+func RunDATestSuite(t *testing.T, dummy *test.DummyDA) {
 	t.Run("Basic DA test", func(t *testing.T) {
 		BasicDATest(t, dummy)
 	})

--- a/test/dummy.go
+++ b/test/dummy.go
@@ -1,4 +1,4 @@
-package da_test
+package test
 
 import (
 	"bytes"

--- a/test/dummy.go
+++ b/test/dummy.go
@@ -26,6 +26,7 @@ type kvp struct {
 	key, value []byte
 }
 
+// NewDummyDA create new instance of DummyDA
 func NewDummyDA() *DummyDA {
 	da := &DummyDA{
 		data: make(map[uint64][]kvp),
@@ -36,6 +37,7 @@ func NewDummyDA() *DummyDA {
 
 var _ da.DA = &DummyDA{}
 
+// Get returns Blobs for given IDs.
 func (d *DummyDA) Get(ids []da.ID) ([]da.Blob, error) {
 	blobs := make([]da.Blob, len(ids))
 	for i, id := range ids {
@@ -57,6 +59,7 @@ func (d *DummyDA) Get(ids []da.ID) ([]da.Blob, error) {
 	return blobs, nil
 }
 
+// GetIDs returns IDs of Blobs at given DA height.
 func (d *DummyDA) GetIDs(height uint64) ([]da.ID, error) {
 	kvps := d.data[height]
 	ids := make([]da.ID, len(kvps))
@@ -66,6 +69,7 @@ func (d *DummyDA) GetIDs(height uint64) ([]da.ID, error) {
 	return ids, nil
 }
 
+// Commit returns cryptographic Commitments for given blobs.
 func (d *DummyDA) Commit(blobs []da.Blob) ([]da.Commitment, error) {
 	commits := make([]da.Commitment, len(blobs))
 	for i, blob := range blobs {
@@ -74,6 +78,7 @@ func (d *DummyDA) Commit(blobs []da.Blob) ([]da.Commitment, error) {
 	return commits, nil
 }
 
+// Submit stores blobs in DA layer.
 func (d *DummyDA) Submit(blobs []da.Blob) ([]da.ID, []da.Proof, error) {
 	ids := make([]da.ID, len(blobs))
 	proofs := make([]da.Proof, len(blobs))
@@ -88,6 +93,7 @@ func (d *DummyDA) Submit(blobs []da.Blob) ([]da.ID, []da.Proof, error) {
 	return ids, proofs, nil
 }
 
+// Validate checks the Proofs for given IDs.
 func (d *DummyDA) Validate(ids []da.ID, proofs []da.Proof) ([]bool, error) {
 	if len(ids) != len(proofs) {
 		return nil, errors.New("number of IDs doesn't equal to number of proofs")


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
`DummyDA` is a simple, in-memory, minimalistic DA implementation for test purposes. It is used to validate unit tests in this repo, but should be public, so it can be used as "mock" by projects using `go-da` (for example to replace mock da in rollkit).

Resolves #6
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
