### PR TITLE
update ci to use a single GO_VERSION setting in ci_release.yml

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -24,11 +24,29 @@ on:
           - major
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    env:
+      # use consistent go version throughout pipeline here
+      GO_VERSION: "1.21"
+    outputs:
+      go-version: ${{ steps.set-vars.outputs.go-version }}
+    steps:
+      - name: Set go version
+        id: set-vars
+        run: echo "go-version=${{env.GO_VERSION}}" >> "$GITHUB_OUTPUT"
+
   lint:
+    needs: [setup]
     uses: ./.github/workflows/lint.yml
+    with:
+      go-version: ${{ needs.setup.outputs.go-version }}
 
   test:
+    needs: [setup]
     uses: ./.github/workflows/test.yml
+    with:
+      go-version: ${{ needs.setup.outputs.go-version }}
 
   proto:
     uses: ./.github/workflows/proto.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,11 @@
 name: lint
 on:
   workflow_call:
+    inputs:
+      go-version:
+        description: 'Go version to use'
+        type: string
+        required: true
 
 jobs:
   golangci-lint:
@@ -12,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: ./go.mod
+          go-version: ${{ inputs.go-version }}
         # This steps sets the GIT_DIFF environment variable to true
         # if files defined in PATTERS changed
       - uses: technote-space/get-diff-action@v6.1.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,11 @@
 name: Tests / Code Coverage
 on:
   workflow_call:
+    inputs:
+      go-version:
+        description: "Go version to use"
+        type: string
+        required: true
 
 jobs:
   go_mod_tidy_check:
@@ -12,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: ./go.mod
+          go-version: ${{ inputs.go-version }}
       - run: go mod tidy
       - name: check for diff
         run: git diff --exit-code
@@ -25,7 +30,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v5
         with:
-          go-version-file: ./go.mod
+          go-version: ${{ inputs.go-version }}
       - name: Run unit test
         run: make test
       - name: upload coverage report
@@ -42,6 +47,6 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v5
         with:
-          go-version-file: ./go.mod
+          go-version: ${{ inputs.go-version }}
       - name: Integration Tests
         run: echo "No integration tests yet"


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

update ci to use a single GO_VERSION setting in ci_release.yml and set that version to output and uses in descendent workflows refs #16


## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Introduced a new "setup" job in the CI release workflow, which sets and outputs the Go version. This change enhances consistency and dependency management in the workflow.
	- Updated the variable name from `GO_VERSION` to `go-version` in the `lint` and `test` workflows, ensuring uniformity across different workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->