### PR TITLE
Add lock around dummy DA data

### DIFF
--- a/test/dummy.go
+++ b/test/dummy.go
@@ -17,11 +17,11 @@ import (
 // Data is stored in a map, where key is a serialized sequence number. This key is returned as ID.
 // Commitments are simply hashes, and proofs are ED25519 signatures.
 type DummyDA struct {
-	mu      *sync.Mutex // protects data
+	mu      *sync.Mutex // protects data and height
 	data    map[uint64][]kvp
+	height  uint64
 	privKey ed25519.PrivateKey
 	pubKey  ed25519.PublicKey
-	height  uint64
 }
 
 type kvp struct {

--- a/test/test_suite.go
+++ b/test/test_suite.go
@@ -153,7 +153,7 @@ func ConcurrentReadWriteTest(t *testing.T, da da.DA) {
 
 	go func() {
 		defer wg.Done()
-		for i := uint64(0); i < 10; i++ {
+		for i := uint64(0); i < 100; i++ {
 			_, err := da.GetIDs(i)
 			assert.NoError(t, err)
 		}
@@ -161,7 +161,7 @@ func ConcurrentReadWriteTest(t *testing.T, da da.DA) {
 
 	go func() {
 		defer wg.Done()
-		for i := uint64(0); i < 10; i++ {
+		for i := uint64(0); i < 100; i++ {
 			_, _, err := da.Submit([][]byte{[]byte("test")})
 			assert.NoError(t, err)
 		}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Closes: #22 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved thread-safety in data access methods by introducing mutex locks.

- **Tests**
  - Added a new test to ensure no race conditions occur during concurrent read/write operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->