### PR TITLE
ci: fix golangci-lint remove inactive linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ run:
 
 linters:
   enable:
-    - deadcode
     - errcheck
     - gofmt
     - goimports
@@ -20,10 +19,8 @@ linters:
     - misspell
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
 
 issues:
   exclude-use-default: false


### PR DESCRIPTION
## Overview

This PR fixes linting failures because `deadcode`, `structcheck`, `varcheck` are now inactivated.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated linter settings to enhance code quality checks by disabling `deadcode`, `structcheck`, and `varcheck` linters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->