### PR TITLE
feat: remove devops from reviewers

### DIFF
--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -10,21 +10,12 @@ reviewers:
       - Manav-Aggarwal
       - S1nus
       - tuxcanfly
-    devops:
-      - smuu
-      - sysrex
-      - jrmanes
-      - Bidon15
     celestia:
       - team:celestia
 files:
   '**':
     - code-owners
     - rollkit
-  '**/*Dockerfile':
-    - devops
-  '.github/**':
-    - devops
 options:
   ignore_draft: true
   ignored_keywords:


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated review configuration to assign `celestia` team as reviewers for all files.
  - Removed `devops` team and specific file paths from the review configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->