### PR TITLE
fix: take care of the case where the requested height is above the head of latest da block height

### DIFF
--- a/test/dummy.go
+++ b/test/dummy.go
@@ -82,7 +82,10 @@ func (d *DummyDA) Get(ctx context.Context, ids []da.ID, _ da.Namespace) ([]da.Bl
 func (d *DummyDA) GetIDs(ctx context.Context, height uint64, _ da.Namespace) ([]da.ID, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	kvps := d.data[height]
+	kvps, ok := d.data[height]
+	if !ok {
+		return nil, errors.New("no blobs at given height")
+	}
 	ids := make([]da.ID, len(kvps))
 	for i, kv := range kvps {
 		ids[i] = kv.key

--- a/test/dummy.go
+++ b/test/dummy.go
@@ -94,7 +94,7 @@ func (d *DummyDA) GetIDs(ctx context.Context, height uint64, _ da.Namespace) ([]
 	if !ok {
 		return nil, nil
 	}
-  
+
 	ids := make([]da.ID, len(kvps))
 	for i, kv := range kvps {
 		ids[i] = kv.key

--- a/test/dummy.go
+++ b/test/dummy.go
@@ -16,8 +16,8 @@ import (
 // DefaultMaxBlobSize is the default max blob size
 const DefaultMaxBlobSize = 64 * 64 * 482
 
-// ErrNoBlobAtHeight is returned when there is no blob at given height.
-var ErrNoBlobAtHeight = errors.New("no blob at given height")
+// ErrTooHigh is returned when requested height is to high
+var ErrTooHigh = errors.New("given height is from the future")
 
 // DummyDA is a simple implementation of in-memory DA. Not production ready! Intended only for testing!
 //
@@ -85,10 +85,16 @@ func (d *DummyDA) Get(ctx context.Context, ids []da.ID, _ da.Namespace) ([]da.Bl
 func (d *DummyDA) GetIDs(ctx context.Context, height uint64, _ da.Namespace) ([]da.ID, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+
+	if height > d.height {
+		return nil, ErrTooHigh
+	}
+
 	kvps, ok := d.data[height]
 	if !ok {
-		return nil, ErrNoBlobAtHeight
+		return nil, nil
 	}
+
 	ids := make([]da.ID, len(kvps))
 	for i, kv := range kvps {
 		ids[i] = kv.key

--- a/test/dummy.go
+++ b/test/dummy.go
@@ -16,6 +16,9 @@ import (
 // DefaultMaxBlobSize is the default max blob size
 const DefaultMaxBlobSize = 64 * 64 * 482
 
+// ErrNoBlobAtHeight is returned when there is no blob at given height.
+var ErrNoBlobAtHeight = errors.New("no blob at given height")
+
 // DummyDA is a simple implementation of in-memory DA. Not production ready! Intended only for testing!
 //
 // Data is stored in a map, where key is a serialized sequence number. This key is returned as ID.
@@ -84,7 +87,7 @@ func (d *DummyDA) GetIDs(ctx context.Context, height uint64, _ da.Namespace) ([]
 	defer d.mu.Unlock()
 	kvps, ok := d.data[height]
 	if !ok {
-		return nil, errors.New("no blobs at given height")
+		return nil, ErrNoBlobAtHeight
 	}
 	ids := make([]da.ID, len(kvps))
 	for i, kv := range kvps {

--- a/test/test_suite.go
+++ b/test/test_suite.go
@@ -3,7 +3,6 @@ package test
 import (
 	"bytes"
 	"context"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -138,9 +137,7 @@ func ConcurrentReadWriteTest(t *testing.T, d da.DA) {
 		defer wg.Done()
 		for i := uint64(1); i <= 100; i++ {
 			_, err := d.GetIDs(ctx, i, []byte{})
-			if err != nil && !strings.Contains(err.Error(), ErrNoBlobAtHeight.Error()) {
-				assert.NoError(t, err)
-			}
+			assert.NoError(t, err)
 		}
 	}()
 

--- a/test/test_suite.go
+++ b/test/test_suite.go
@@ -28,6 +28,9 @@ func RunDATestSuite(t *testing.T, d da.DA) {
 	t.Run("Concurrent read/write test", func(t *testing.T) {
 		ConcurrentReadWriteTest(t, d)
 	})
+	t.Run("No blobs at a given height", func(t *testing.T) {
+		NoBlobsAtHeightTest(t, d)
+	})
 }
 
 // BasicDATest tests round trip of messages to DA and back.
@@ -133,8 +136,7 @@ func ConcurrentReadWriteTest(t *testing.T, d da.DA) {
 	go func() {
 		defer wg.Done()
 		for i := uint64(1); i <= 100; i++ {
-			_, err := d.GetIDs(ctx, i, []byte{})
-			assert.NoError(t, err)
+			_, _ = d.GetIDs(ctx, i, []byte{})
 		}
 	}()
 
@@ -147,4 +149,10 @@ func ConcurrentReadWriteTest(t *testing.T, d da.DA) {
 	}()
 
 	wg.Wait()
+}
+
+func NoBlobsAtHeightTest(t *testing.T, d da.DA) {
+	ctx := context.TODO()
+	_, err := d.GetIDs(ctx, 888888, []byte{})
+	assert.Error(t, err)
 }

--- a/test/test_suite.go
+++ b/test/test_suite.go
@@ -137,7 +137,9 @@ func ConcurrentReadWriteTest(t *testing.T, d da.DA) {
 		defer wg.Done()
 		for i := uint64(1); i <= 100; i++ {
 			_, err := d.GetIDs(ctx, i, []byte{})
-			assert.NoError(t, err)
+			if err != nil {
+				assert.Equal(t, err.Error(), ErrTooHigh.Error())
+			}
 		}
 	}()
 

--- a/test/test_suite.go
+++ b/test/test_suite.go
@@ -151,6 +151,7 @@ func ConcurrentReadWriteTest(t *testing.T, d da.DA) {
 	wg.Wait()
 }
 
+// NoBlobsAtHeightTest tests the case when there are no blobs at a given height in DA
 func NoBlobsAtHeightTest(t *testing.T, d da.DA) {
 	ctx := context.TODO()
 	_, err := d.GetIDs(ctx, 888888, []byte{})

--- a/test/test_suite.go
+++ b/test/test_suite.go
@@ -3,6 +3,7 @@ package test
 import (
 	"bytes"
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -136,7 +137,10 @@ func ConcurrentReadWriteTest(t *testing.T, d da.DA) {
 	go func() {
 		defer wg.Done()
 		for i := uint64(1); i <= 100; i++ {
-			_, _ = d.GetIDs(ctx, i, []byte{})
+			_, err := d.GetIDs(ctx, i, []byte{})
+			if err != nil && !strings.Contains(err.Error(), ErrNoBlobAtHeight.Error()) {
+				assert.NoError(t, err)
+			}
 		}
 	}()
 
@@ -154,6 +158,8 @@ func ConcurrentReadWriteTest(t *testing.T, d da.DA) {
 // NoBlobsAtHeightTest tests the case when there are no blobs at a given height in DA
 func NoBlobsAtHeightTest(t *testing.T, d da.DA) {
 	ctx := context.TODO()
-	_, err := d.GetIDs(ctx, 888888, []byte{})
+	// GetIDs should return ErrNoBlobAtHeight when there are no blobs at a given height
+	_, err := d.GetIDs(ctx, 999999999, []byte{})
 	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), ErrNoBlobAtHeight.Error()))
 }


### PR DESCRIPTION
We need to handle the case where full node goes above the max height of the da, so it's consistent with real world da implementations, and handled correctly by the full node retrieve loop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced error handling for height validation, providing clearer messages for future height requests.
	- Updated test suite to reflect changes in error handling and improve clarity in testing scenarios.

- **Bug Fixes**
	- Simplified error handling logic in tests to ensure robustness and accuracy in function outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->