### PR TITLE
chore: add module retraction for accidental v0.6.0 tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,3 +29,5 @@ require (
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract v0.6.0 // tagged by accident


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Resolves #96 

This retraction prevents users from mistakenly using the incorrect v0.6.0 version. The change clarifies the intended versions available for use.


<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Corrected versioning information by retracting the accidental version `v0.6.0` in the module's dependency management. This change clarifies the intended state of the module's dependencies without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->