### PR TITLE
feat(ci): Add semantic PR action and semantic release

### DIFF
--- a/.github/workflows/semantic_pull_request.yml
+++ b/.github/workflows/semantic_pull_request.yml
@@ -1,0 +1,20 @@
+name: Semantic Pull Request
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: conventional-commit-pr-title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -1,0 +1,24 @@
+name: Semantic Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configure Semantic Release
+        # Work around for non npm project
+        # REF: https://github.com/cycjimmy/semantic-release-action/issues/115#issuecomment-1817264419
+        run: echo '{"branches":[],"plugins":["@semantic-release/commit-analyzer","@semantic-release/release-notes-generator","@semantic-release/github"]}' > .releaserc.json
+      - name: Create Release
+        uses: cycjimmy/semantic-release-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branches: |
+            ["main"]


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

This PR introduces an option for auto semantic releases and the prerequisite semantic PR action. 

The semantic release action will trigger on `fix` and `feat` commits to main creating `patch` and `minor` releases respectively. 

To trigger a `major` release, you can add `BREAKING CHANGE` in the commit message during the merge, see screenshot.
<img width="822" alt="Screenshot 2024-09-19 at 3 33 24 PM" src="https://github.com/user-attachments/assets/bef59adf-9a76-4ec5-a156-5da19c791b6a">

It is important to note that by default the breaking change will trigger a `major` release, so while we are on `v0.x` we should avoid triggering the major releases until we have released a `v1`.

In my testing, I did not see the workflow trigger a release on `chore`, `test`, or `docs` commits. So it is important that when submitting and review PRs are are consistent in our semantic commit usage to ensure releases are triggered as intended. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a GitHub Actions workflow for enforcing semantic pull request practices, enhancing commit message consistency.
	- Added a workflow for automating semantic versioning and release management, streamlining the release cycle based on commit messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->