### PR TITLE
fix: handle ErrBlobNotFound error on proxy level

### DIFF
--- a/proxy/grpc/server.go
+++ b/proxy/grpc/server.go
@@ -44,6 +44,11 @@ func (p *proxySrv) GetIds(ctx context.Context, request *pbda.GetIdsRequest) (*pb
 		return nil, err
 	}
 
+	// for ErrBlobNotFound cases
+	if ret == nil {
+		return &pbda.GetIdsResponse{Ids: []*pbda.ID{}, Timestamp: nil}, nil
+	}
+
 	timestamp, err := types.TimestampProto(ret.Timestamp)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We need to handle [this case](https://github.com/celestiaorg/celestia-node/blob/87bc6c891949c80d1a68389af45c8bae87588597/nodebuilder/da/service.go#L97) on the proxy level. 

It's handled in dummy implementation [here](https://github.com/rollkit/go-da/blob/main/test/dummy.go#L95)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling to gracefully manage scenarios where no IDs are found, returning an empty response instead of an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->